### PR TITLE
enhance: fixtures types

### DIFF
--- a/src/config/tests/fixtures/index.ts
+++ b/src/config/tests/fixtures/index.ts
@@ -2,19 +2,19 @@ import * as TE from 'fp-ts/TaskEither'
 import { pipe } from 'fp-ts/function'
 
 export function unsafe <T> (value: unknown): T {
-  return value as any
+  return value as T
 }
 
-type Callback = (a: unknown) => unknown
-type MapAll = (fn: Callback) => (data: TE.TaskEither<unknown, unknown>) =>
-  TE.TaskEither<unknown, unknown>
+type Callback<E, T> = (a: E | T) => unknown
 
-export const mapAll: MapAll = (fn) => (data) => {
-  return pipe(
-    data,
-    TE.map(fn),
-    TE.mapLeft(fn),
-  )
+export function mapAll<E, T> (fn: Callback<E, T>) {
+  return function (data: TE.TaskEither<E, T>) {
+    return pipe(
+      data,
+      TE.map(fn),
+      TE.mapLeft(fn),
+    )
+  }
 }
 
 export function getErrorMessage (errors: unknown): string {


### PR DESCRIPTION
Hi @fdaciuk 

First of all, thanks for this awesome content with fp-ts :)

Here are some suggestions for enhance the typing of fixtures, more exaclty the `mapAll` function

With those generics we can infer some typings coming from the TE.

So now, when using the mapAll, the callback function receives either an Error, or the actual type instead of unknown:

![image](https://user-images.githubusercontent.com/38966428/126668959-4c41a925-9a36-4aac-b277-a105c6625c91.png)
