### PR TITLE
Validate login request

### DIFF
--- a/src/ports/express/server.ts
+++ b/src/ports/express/server.ts
@@ -5,7 +5,6 @@ import express, {
 } from 'express'
 import { pipe } from 'fp-ts/function'
 import * as TE from 'fp-ts/TaskEither'
-import * as E from 'fp-ts/Either'
 import cors from 'cors'
 import {
   registerUser,
@@ -53,10 +52,8 @@ app.post('/api/users', async (req: Request, res: Response) => {
 
 app.post('/api/users/login', async (req: Request, res: Response) => {
   return pipe(
-    TE.tryCatch(
-      () => login(req.body.user),
-      E.toError,
-    ),
+    req.body.user,
+    login,
     TE.map(result => res.json(result)),
     TE.mapLeft(error => res.status(422).json(getError(error.message))),
   )()


### PR DESCRIPTION
Hi once again @fdaciuk how it's going?

I was looking into the project and noticed that some functions on the ports folder doesn't approach the pattern with fp-ts/io-ts and I felt that would be worth making a little refactor on those.
What do you think? 
I initiated this with some login functions that were simpler, if you think it's a good idea I can go on with other files/functions.

Also, (not exactly sure whether it's an error or not) this fixes a little problem with the login request. It wasn't validating the input, so every problem would return the error `Invalid email or password`. Now it can return like:
```json
{
  "errors": {
    "body": [
      "Invalid email",
      "Password should be at least 8 characters long."
    ]
  }
}
```